### PR TITLE
fix: renamed font color attribute in Track.java

### DIFF
--- a/src/main/java/openevent/model/Track.java
+++ b/src/main/java/openevent/model/Track.java
@@ -10,7 +10,7 @@ public class Track {
     private String name;
     private String description;
     private String color;
-    @JsonProperty("font-color")
+    @JsonProperty("font_color")
     private String fontColor;
     private List<Session> sessions;
 


### PR DESCRIPTION
@iamareebjamal @Shailesh351 

In Track.java I just found out that we were using "font-color" instead of "font_color".
